### PR TITLE
Fix: bug in validation short number error message

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -73,7 +73,7 @@ function getValidationError(number, countryCode) {
     if (e.message == i18n.phonenumbers.Error.INVALID_COUNTRY_CODE) {
       return i18n.phonenumbers.PhoneNumberUtil.ValidationResult.INVALID_COUNTRY_CODE;
     }
-    if (e.message == i18n.phonenumbers.Error.TOO_SHORT_AFTER_IDD || e == i18n.phonenumbers.Error.TOO_SHORT_NSN) {
+    if (e.message == i18n.phonenumbers.Error.TOO_SHORT_AFTER_IDD || e.message == i18n.phonenumbers.Error.TOO_SHORT_NSN) {
       return i18n.phonenumbers.PhoneNumberUtil.ValidationResult.TOO_SHORT;
     }
     if (e.message == i18n.phonenumbers.Error.TOO_LONG) {


### PR DESCRIPTION
It's showing undefined as error message in validation when only single digit is entered. That's fixed in this commit.

![image](https://user-images.githubusercontent.com/10610475/85919272-73232400-b887-11ea-90e4-b6b79a7bffce.png)
